### PR TITLE
Resolve the problem that the alarm probability associated with the pod is not cleared

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -85,6 +85,7 @@ const (
 const (
 	ContainerUnhealthy    = "Unhealthy"
 	ContainerProbeWarning = "ProbeWarning"
+	ContainerHealthy      = "Healthy"
 )
 
 // Pod worker event reason list

--- a/staging/src/k8s.io/client-go/tools/record/BUILD
+++ b/staging/src/k8s.io/client-go/tools/record/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/client-go/tools/record",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kubelet/events:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 )
 
 const (
@@ -499,7 +500,7 @@ func (c *EventCorrelator) EventCorrelate(newEvent *v1.Event) (*EventCorrelateRes
 	}
 	aggregateEvent, ckey := c.aggregator.EventAggregate(newEvent)
 	observedEvent, patch, err := c.logger.eventObserve(aggregateEvent, ckey)
-	if c.filterFunc(observedEvent) {
+	if c.filterFunc(observedEvent) && newEvent.Reason != events.ContainerHealthy{
 		return &EventCorrelateResult{Skip: true}, nil
 	}
 	return &EventCorrelateResult{Event: observedEvent, Patch: patch}, err

--- a/vendor/github.com/seccomp/libseccomp-golang/BUILD
+++ b/vendor/github.com/seccomp/libseccomp-golang/BUILD
@@ -7,7 +7,6 @@ go_library(
         "seccomp_internal.go",
     ],
     cgo = True,
-    clinkopts = select({"@io_bazel_rules_go//go/platform:linux":["-lseccomp",],"//conditions:default":[],}),
     importmap = "k8s.io/kubernetes/vendor/github.com/seccomp/libseccomp-golang",
     importpath = "github.com/seccomp/libseccomp-golang",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When kubelet sends an event event for a certain object, it will limit the flow.if the pod has a large number of event events in a short period of time, after the pod starts up normally, the healthy events will probably not be sent due to the flow limit, which will prevent the pod related alarms from being cleared in time.
Modify the condition of the flow limit judgment, release the judgment of healthy events, and ensure that healthy events can be sent successfully.

**Which issue(s) this PR fixes**:
Part of #95637

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

